### PR TITLE
User sepcific settings file only override default settings file

### DIFF
--- a/src/picast/settings.py
+++ b/src/picast/settings.py
@@ -40,20 +40,20 @@ class Settings(object):
         if self._config is None:
             with self._lock:
                 if self._config is None:
-                    if config is None:
-                        inidir = os.path.dirname(__file__)
-                        self.inifile = os.path.join(inidir, "settings.ini")
-                    else:
-                        inidir = os.path.dirname(config)
-                        self.inifile = config
-                    self._config = self.configParse(self.inifile)
-                    self._platform = self._detect_platform()
+                    self._config = self.configParse(config)
 
-    def configParse(self, file_path):
-        if not os.path.exists(file_path):
-            raise IOError(file_path)
+    def configParse(self, custom_config):
+        inidir = os.path.dirname(__file__)
+        self.inifile = os.path.join(inidir, "settings.ini")
+        filenames = [self.inifile]
+        if custom_config is not None:
+            if not os.path.exists(custom_config):
+                raise IOError(custom_config)
+            inidir = os.path.dirname(custom_config)
+            self.inifile = custom_config
+            filenames.append(custom_config)
         config = configparser.ConfigParser()
-        config.read(file_path)
+        config.read(filenames)
         return config
 
     def _detect_platform(self):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,4 +1,5 @@
 import os
+import tempfile
 from logging import config as LoggingConfig
 
 from picast.settings import Settings
@@ -12,6 +13,22 @@ def test_logging_config():
 
 
 @pytest.mark.unit
+def test_config_override():
+    fd, temp_path = tempfile.mkstemp()
+    with open(temp_path, "w") as f:
+        f.write("[player]\n")
+        f.write("name=nop\n")
+    Settings()._config = None # Clean singletone state
+    assert Settings().device_name == 'picast'
+    assert Settings().player == 'vlc'
+    Settings()._config = None # Clena singletone state
+    assert Settings(config=temp_path).device_name == 'picast'
+    assert Settings(config=temp_path).player == 'nop'
+    Settings()._config = None # Clena singletone state
+    os.unlink(temp_path)
+
+
+@pytest.mark.unit
 def test_config_logger():
     assert Settings().logger == 'picast'
 
@@ -19,6 +36,7 @@ def test_config_logger():
 @pytest.mark.unit
 def test_config_logging_config():
     assert Settings().logging_config == 'logging.ini'
+
 
 @pytest.mark.unit
 def test_config_myaddress():


### PR DESCRIPTION
* Will load built-in "settings.ini" always as default and override it with customer "-c" provided if any on top of that.

This fixes #34 