### PR TITLE
No need to initiate find from pi side, as it does not initiate p2p co…

### DIFF
--- a/src/picast/wifip2p.py
+++ b/src/picast/wifip2p.py
@@ -82,7 +82,6 @@ class WifiP2PServer(threading.Thread):
 
     def create_p2p_interface(self, R2):
         wpacli = WpaCli()
-        wpacli.start_p2p_find()
         wpacli.set_device_name(self.config.device_name)
         wpacli.set_device_type(self.config.device_type)
         wpacli.set_p2p_go_ht40()


### PR DESCRIPTION
* Stop using p2p find, as it is not necessary for pi side, as all group join and stop si initiated from the other side

Fixes #37 